### PR TITLE
Password validation #22

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    flash[:warning] = 'ログインしてください'
+    flash[:warning] = 'ログインする必要があります'
     redirect_to login_path
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }          # passwordが一致しているかの比較
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] } # password_confirmationが空白でないこと
   validates :password, format: { with: /\A[a-zA-Z0-9]+\z/,
-                       message: 'は半角英数字3文字以上含む必要があります' }
+                       message: 'は半角英数字を3文字以上含む必要があります' }
 
   validates :email, uniqueness: true,                                                                    # メールアドレスが重複しないこと
                     presence: true,                                                                    # メールアドレスが空白でないこと

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }      # 3文字以上
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }          # passwordが一致しているかの比較
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] } # password_confirmationが空白でないこと
+  validates :password, format: { with: /\A[a-zA-Z0-9]+\z/,
+                       message: 'は半角英数字3文字以上含む必要があります' }
 
   validates :email, uniqueness: true,                                                                    # メールアドレスが重複しないこと
                     presence: true,                                                                    # メールアドレスが空白でないこと

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,7 +2,7 @@
   <%# <%= f.input :name,  required: false, placeholder: '山田 太郎' %1><br /> %>
   <%= f.input :name,  placeholder: '山田 太郎' %><br />
   <%= f.input :email, placeholder: 'example@example.com' %><br />
-  <%= f.input :password, hint: '※3文字以上で入力してください' %><br />
+  <%= f.input :password, hint: '※ 半角英数字、3文字以上で入力してください' %><br />
   <%= f.input :password_confirmation %><br />
   <%= f.submit class: 'btn btn-primary' %>
 <% end %>


### PR DESCRIPTION
## 概要
パスワードの全角入力をできないようにバリデーションを追加しました。

## コメント
全角入力でパスワードを作成してしまうと、ユーザーが戸惑うこともあるので半角英数字のみにしました。

##参考にしたサイト
[正規表現](https://gist.github.com/nashirox/38323d5b51063ede1d41)
[フォーマット](https://qiita.com/E6YOteYPzmFGfOD/items/807d63cfb7f5f34d4314)